### PR TITLE
feat: make component images configurable

### DIFF
--- a/charts/glassflow-operator/templates/deployment.yaml
+++ b/charts/glassflow-operator/templates/deployment.yaml
@@ -37,6 +37,12 @@ spec:
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
+        - name: INGESTOR_IMAGE
+          value: {{ .Values.componentImages.ingestor.repository }}:{{ .Values.componentImages.ingestor.tag }}
+        - name: JOIN_IMAGE
+          value: {{ .Values.componentImages.join.repository }}:{{ .Values.componentImages.join.tag }}
+        - name: SINK_IMAGE
+          value: {{ .Values.componentImages.sink.repository }}:{{ .Values.componentImages.sink.tag }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.controllerManager.manager.image.pullPolicy }}
         livenessProbe:

--- a/charts/glassflow-operator/values.yaml
+++ b/charts/glassflow-operator/values.yaml
@@ -24,6 +24,20 @@ controllerManager:
   serviceAccount:
     annotations: {}
 kubernetesClusterDomain: cluster.local
+
+# Component image configurations
+componentImages:
+  ingestor:
+    repository: ghcr.io/glassflow/glassflow-etl-ingestor
+    tag: glassflow-cloud
+  join:
+    repository: ghcr.io/glassflow/glassflow-etl-join
+    tag: glassflow-cloud
+  sink:
+    repository: ghcr.io/glassflow/glassflow-etl-sink
+    tag: glassflow-cloud
+
+
 metricsService:
   ports:
   - name: https


### PR DESCRIPTION
In k8 operator component images were hardcoded to `glassflow-cloud` branch

I've updated the operator to read the component images from ENV args 

This PR adds the defaults in operator values.yaml & args in deployment.yaml