### PR TITLE
ETL-782: Introduce PGBouncer for PostgreSQL connection pooling

### DIFF
--- a/charts/glassflow-etl/templates/hooks/usage-stats/pre-install.yaml
+++ b/charts/glassflow-etl/templates/hooks/usage-stats/pre-install.yaml
@@ -35,21 +35,31 @@ spec:
               set +e  # Don't exit on errors - make failures non-blocking
               
               apk add --no-cache jq uuidgen >/dev/null 2>&1
-              
-              {{- if .Values.global.usageStats.installationId }}
-              INSTALLATION_ID="{{ .Values.global.usageStats.installationId }}"
-              {{- else }}
-              INSTALLATION_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
-              {{- end }}
+
               USAGE_STATS_ENDPOINT="https://tracking.glassflow.dev/api/v1"
               USAGE_STATS_USERNAME="5PR3vzYGGlYttkBXRTYuzw=="
               USAGE_STATS_PASSWORD="5tJcYQNR85KKyOwpeIFVdGqGIOgFwxmWEHu0t7WxBbo="
-              
+
               KUBE_API="https://kubernetes.default.svc"
               TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
               CA_CERT="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
               NAMESPACE="{{ .Release.Namespace }}"
               SECRET_NAME="{{ .Release.Name }}-usage-stats-config"
+
+              # Read existing secret first — needed both for ID preservation and POST vs PATCH decision
+              EXISTING_SECRET=$(curl -sS --max-time 5 --cacert "$CA_CERT" \
+                -H "Authorization: Bearer $TOKEN" \
+                "$KUBE_API/api/v1/namespaces/$NAMESPACE/secrets/$SECRET_NAME" 2>/dev/null || echo "{}")
+
+              {{- if .Values.global.usageStats.installationId }}
+              INSTALLATION_ID="{{ .Values.global.usageStats.installationId }}"
+              {{- else }}
+              # Preserve existing installation ID on upgrades — only generate a new one on first install
+              INSTALLATION_ID=$(echo "$EXISTING_SECRET" | jq -r '.data.installation_id // empty' | base64 -d 2>/dev/null)
+              if [ -z "$INSTALLATION_ID" ]; then
+                INSTALLATION_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+              fi
+              {{- end }}
               
               echo "Usage stats: Getting auth token..."
               AUTH_RESP=$(curl -sS --max-time 10 -X POST \
@@ -196,11 +206,6 @@ spec:
                 echo "WARNING: Usage stats - Failed to create secret data, continuing anyway"
                 exit 0
               fi
-              
-              # Try to get existing secret first to preserve metadata
-              EXISTING_SECRET=$(curl -sS --max-time 5 --cacert "$CA_CERT" \
-                -H "Authorization: Bearer $TOKEN" \
-                "$KUBE_API/api/v1/namespaces/$NAMESPACE/secrets/$SECRET_NAME" 2>/dev/null || echo "{}")
               
               if echo "$EXISTING_SECRET" | jq -e '.kind == "Secret"' >/dev/null 2>&1; then
                 # Secret exists, use PATCH to update it


### PR DESCRIPTION
## Summary

Introduces PGBouncer as an optional connection pooler for the internal PostgreSQL deployment. Addresses connection exhaustion when many pipeline component replicas each maintain their own connection pool to Postgres (particularly relevant with schema evolution, where every ingestor/sink connects to Postgres to fetch schemas).

- **New chart** `charts/pgbouncer/` (bitnami/pgbouncer, v0.1.0) — transaction pooling by default, fully configurable
- **postgresql chart** bumped to v0.1.9 — when `global.pgbouncer.enabled=true`, `connection-url` in the `glassflow-postgresql` secret points to PGBouncer; original Postgres URL stored in `direct-connection-url`
- **glassflow-etl chart** — adds `pgbouncer` subchart dependency and `pgbouncer:` config section; DB migration init container automatically uses `direct-connection-url` (bypasses PGBouncer) when enabled
- **release.yaml** — CI pre-packages local subcharts before `helm dependency update` so new subchart versions resolve in the same PR as the parent chart

## How it works

PGBouncer is transparent to all components:
- Operator and pipeline components read `glassflow-postgresql/connection-url` as before — it now points to PGBouncer when enabled
- Migrations connect directly to Postgres via `direct-connection-url`
- No changes to operator chart, component images, or schema evolution code

## Usage

```bash
# Enable PGBouncer (only supported with internal PostgreSQL)
helm upgrade glassflow glassflow-etl/ --set global.pgbouncer.enabled=true

# Tune pool settings
helm upgrade glassflow glassflow-etl/ \
  --set global.pgbouncer.enabled=true \
  --set pgbouncer.defaultPoolSize=30 \
  --set pgbouncer.maxClientConn=200
```

For external PostgreSQL users: manage your own connection pooler and point `global.postgres.connection_url` to it directly.

## Backward compatibility

`global.pgbouncer.enabled` defaults to `false`. Zero impact on existing deployments.

Closes ETL-782