### PR TITLE
Chart metadata for ArtifactHub: logo, home, description (ETL-1088)

### DIFF
--- a/charts/glassflow-etl/Chart.yaml
+++ b/charts/glassflow-etl/Chart.yaml
@@ -1,6 +1,8 @@
 apiVersion: v2
 name: glassflow-etl
-description: A Helm chart for Kubernetes
+description: Streaming ETL for ClickHouse — deduplication, joins, and transforms over Kafka and other sources
+home: https://www.glassflow.dev
+icon: https://charts.glassflow.dev/logo.svg
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.17
+version: 0.5.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Adds the GlassFlow logo, homepage URL, and a meaningful chart description so the [glassflow-etl chart page on ArtifactHub](https://artifacthub.io/packages/helm/glassflow/glassflow-etl) renders properly.

## Changes

`charts/glassflow-etl/Chart.yaml`:

- `icon: https://charts.glassflow.dev/logo.svg` — square colored logomark (uploaded separately to `gh-pages`, already live)
- `home: https://www.glassflow.dev`
- `description: Streaming ETL for ClickHouse — deduplication, joins, and transforms over Kafka and other sources` (replaces helm-create default `A Helm chart for Kubernetes`)
- `version: 0.5.17 → 0.5.18`

## Verification

- `helm lint` clean
- Logo URL responds 200: `curl -sI https://charts.glassflow.dev/logo.svg`
- After merge + release, ArtifactHub picks up the new fields on the next scrape of `index.yaml`.

Resolves ETL-1088.