### PR TITLE
helm: add containerPort to api and ui for prefilled port-forward ports

### DIFF
--- a/charts/glassflow-etl/templates/deployment.yaml
+++ b/charts/glassflow-etl/templates/deployment.yaml
@@ -45,6 +45,10 @@ spec:
         - name: ui
           image: "{{ .Values.global.imageRegistry | default "" }}{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.ui.service.targetPort | default 8080 }}
+              protocol: TCP
           {{- with .Values.ui.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -303,6 +307,10 @@ spec:
         - name: api
           image: "{{ .Values.global.imageRegistry | default "" }}{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.api.service.targetPort | default 8081 }}
+              protocol: TCP
           {{- with .Values.api.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/glassflow-etl/values.yaml
+++ b/charts/glassflow-etl/values.yaml
@@ -11,7 +11,7 @@ global:
   imageRegistry: "ghcr.io/glassflow/"
   observability:
     metrics:
-      enabled: false
+      enabled: true
       # Additional exporters added alongside the built-in Prometheus exporter.
       # The Prometheus scrape endpoint (port 9090) is always enabled when metrics.enabled=true.
       # Use this map to push metrics to additional backends (e.g. otlp, otlphttp).
@@ -98,7 +98,7 @@ global:
       create: true
 
   usageStats:
-    enabled: false
+    enabled: true
     # Optional: provide an installation ID
     installationId: ""
 
@@ -152,8 +152,8 @@ api:
   logLevel: "info"
   image:
     repository: glassflow-etl-be
-    tag: main
-    pullPolicy: Always
+    tag: v3.1.0
+    pullPolicy: IfNotPresent
   resources:
     requests:
       memory: "100Mi"  # Memory request - adjust based on your workload
@@ -187,8 +187,8 @@ ui:
   replicas: 1
   image:
     repository: glassflow-etl-fe
-    tag: main
-    pullPolicy: Always
+    tag: v3.1.0
+    pullPolicy: IfNotPresent
   logLevel: "info"
   resources:
     requests:
@@ -239,7 +239,7 @@ ui:
     image:
       repository: kafka-kerberos-gateway
       tag: latest
-      pullPolicy: Always
+      pullPolicy: IfNotPresent
     resources:
       requests:
         memory: "128Mi"  # Memory request - gateway is lightweight
@@ -266,8 +266,8 @@ glassflow-operator:
       reconcileTimeout: 15m
       image:
         repository: glassflow-etl-k8s-operator
-        tag: main
-        pullPolicy: Always
+        tag: v3.1.0
+        pullPolicy: IfNotPresent
       resources:
         limits:
           cpu: 500m
@@ -282,8 +282,8 @@ glassflow-operator:
     ingestor:
       image:
         repository: glassflow-etl-ingestor
-        tag: main
-        pullPolicy: Always
+        tag: v3.1.0
+        pullPolicy: IfNotPresent
       logLevel: "INFO"
       resources:
         requests:
@@ -297,8 +297,8 @@ glassflow-operator:
     join:
       image:
         repository: glassflow-etl-join
-        tag: main
-        pullPolicy: Always
+        tag: v3.1.0
+        pullPolicy: IfNotPresent
       logLevel: "INFO"
       resources:
         requests:
@@ -312,8 +312,8 @@ glassflow-operator:
     sink:
       image:
         repository: glassflow-etl-sink
-        tag: main
-        pullPolicy: Always
+        tag: v3.1.0
+        pullPolicy: IfNotPresent
       logLevel: "INFO"
       resources:
         requests:
@@ -327,8 +327,8 @@ glassflow-operator:
     dedup:
       image:
         repository: glassflow-etl-dedup
-        tag: main
-        pullPolicy: Always
+        tag: v3.1.0
+        pullPolicy: IfNotPresent
       logLevel: "INFO"
       resources:
         requests:
@@ -349,12 +349,12 @@ sources:
   # OTLP Receiver - ingests OpenTelemetry data (logs, traces, metrics) via gRPC and HTTP
   # This is a shared service (one per installation) that routes data to pipelines via NATS
   otlpReceiver:
-    enabled: true
+    enabled: false
     replicas: 1
     image:
       repository: glassflow-etl-otlp-receiver
-      tag: main
-      pullPolicy: Always
+      tag: v3.1.0
+      pullPolicy: IfNotPresent
     resources:
       requests:
         memory: "256Mi"
@@ -369,7 +369,7 @@ sources:
     # Max concurrent in-flight batches before the receiver starts shedding load
     # (returns HTTP 503 / gRPC ResourceExhausted). Increase if you need higher
     # throughput but ensure the pod has enough CPU/memory headroom.
-    maxConcurrentRequests: 5
+    maxConcurrentRequests: 50
     # Max messages per NATS async-publish chunk. Keeps per-request memory bounded
     # regardless of upstream batch size.
     natsChunkSize: 1000
@@ -566,11 +566,11 @@ nats:
     merge:
       resources:
         requests:
-          memory: "2Gi"
-          cpu: "1000m"
+          memory: "3Gi"
+          cpu: "4000m"
         limits:
-          memory: "2Gi"
-          cpu: "1000m"
+          memory: "3Gi"
+          cpu: "4000m"
 
 # =============================================================================
 # INGRESS CONFIGURATION

--- a/charts/glassflow-etl/values.yaml
+++ b/charts/glassflow-etl/values.yaml
@@ -11,7 +11,7 @@ global:
   imageRegistry: "ghcr.io/glassflow/"
   observability:
     metrics:
-      enabled: true
+      enabled: false
       # Additional exporters added alongside the built-in Prometheus exporter.
       # The Prometheus scrape endpoint (port 9090) is always enabled when metrics.enabled=true.
       # Use this map to push metrics to additional backends (e.g. otlp, otlphttp).
@@ -98,7 +98,7 @@ global:
       create: true
 
   usageStats:
-    enabled: true
+    enabled: false
     # Optional: provide an installation ID
     installationId: ""
 
@@ -152,8 +152,8 @@ api:
   logLevel: "info"
   image:
     repository: glassflow-etl-be
-    tag: v3.1.0
-    pullPolicy: IfNotPresent
+    tag: main
+    pullPolicy: Always
   resources:
     requests:
       memory: "100Mi"  # Memory request - adjust based on your workload
@@ -187,8 +187,8 @@ ui:
   replicas: 1
   image:
     repository: glassflow-etl-fe
-    tag: v3.1.0
-    pullPolicy: IfNotPresent
+    tag: main
+    pullPolicy: Always
   logLevel: "info"
   resources:
     requests:
@@ -239,7 +239,7 @@ ui:
     image:
       repository: kafka-kerberos-gateway
       tag: latest
-      pullPolicy: IfNotPresent
+      pullPolicy: Always
     resources:
       requests:
         memory: "128Mi"  # Memory request - gateway is lightweight
@@ -266,8 +266,8 @@ glassflow-operator:
       reconcileTimeout: 15m
       image:
         repository: glassflow-etl-k8s-operator
-        tag: v3.1.0
-        pullPolicy: IfNotPresent
+        tag: main
+        pullPolicy: Always
       resources:
         limits:
           cpu: 500m
@@ -282,8 +282,8 @@ glassflow-operator:
     ingestor:
       image:
         repository: glassflow-etl-ingestor
-        tag: v3.1.0
-        pullPolicy: IfNotPresent
+        tag: main
+        pullPolicy: Always
       logLevel: "INFO"
       resources:
         requests:
@@ -297,8 +297,8 @@ glassflow-operator:
     join:
       image:
         repository: glassflow-etl-join
-        tag: v3.1.0
-        pullPolicy: IfNotPresent
+        tag: main
+        pullPolicy: Always
       logLevel: "INFO"
       resources:
         requests:
@@ -312,8 +312,8 @@ glassflow-operator:
     sink:
       image:
         repository: glassflow-etl-sink
-        tag: v3.1.0
-        pullPolicy: IfNotPresent
+        tag: main
+        pullPolicy: Always
       logLevel: "INFO"
       resources:
         requests:
@@ -327,8 +327,8 @@ glassflow-operator:
     dedup:
       image:
         repository: glassflow-etl-dedup
-        tag: v3.1.0
-        pullPolicy: IfNotPresent
+        tag: main
+        pullPolicy: Always
       logLevel: "INFO"
       resources:
         requests:
@@ -349,12 +349,12 @@ sources:
   # OTLP Receiver - ingests OpenTelemetry data (logs, traces, metrics) via gRPC and HTTP
   # This is a shared service (one per installation) that routes data to pipelines via NATS
   otlpReceiver:
-    enabled: false
+    enabled: true
     replicas: 1
     image:
       repository: glassflow-etl-otlp-receiver
-      tag: v3.1.0
-      pullPolicy: IfNotPresent
+      tag: main
+      pullPolicy: Always
     resources:
       requests:
         memory: "256Mi"
@@ -369,7 +369,7 @@ sources:
     # Max concurrent in-flight batches before the receiver starts shedding load
     # (returns HTTP 503 / gRPC ResourceExhausted). Increase if you need higher
     # throughput but ensure the pod has enough CPU/memory headroom.
-    maxConcurrentRequests: 50
+    maxConcurrentRequests: 5
     # Max messages per NATS async-publish chunk. Keeps per-request memory bounded
     # regardless of upstream batch size.
     natsChunkSize: 1000
@@ -566,11 +566,11 @@ nats:
     merge:
       resources:
         requests:
-          memory: "3Gi"
-          cpu: "4000m"
+          memory: "2Gi"
+          cpu: "1000m"
         limits:
-          memory: "3Gi"
-          cpu: "4000m"
+          memory: "2Gi"
+          cpu: "1000m"
 
 # =============================================================================
 # INGRESS CONFIGURATION


### PR DESCRIPTION
## Summary

- Add `containerPort` (8081) to the API container spec
- Add `containerPort` (8080) to the UI container spec

## Context

Without `containerPort` declared in the container spec, tools like k9s have no port to prefill when opening the port-forward dialog — you have to type it manually every time. With this change, k9s (and `kubectl port-forward`) will automatically suggest the correct local port.


<img width="688" height="228" alt="image" src="https://github.com/user-attachments/assets/9fdc0d6b-8a27-4c2c-8ee3-df6cf3af6929" />
