### PR TITLE
ETL-1140: fix OTLP pod metric collapse — resource_to_telemetry_conversion + service.instance.id

### DIFF
--- a/charts/glassflow-etl/Chart.yaml
+++ b/charts/glassflow-etl/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.18
+version: 0.5.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/glassflow-etl/templates/deployment.yaml
+++ b/charts/glassflow-etl/templates/deployment.yaml
@@ -311,6 +311,16 @@ spec:
             - configMapRef:
                 name: glassflow-api-config
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.instance.id=$(POD_NAME),service.namespace=$(POD_NAMESPACE)"
             {{- if .Values.postgresql.enabled }}
             - name: GLASSFLOW_DATABASE_URL
               valueFrom:

--- a/charts/glassflow-etl/templates/otel-collector-configmap.yaml
+++ b/charts/glassflow-etl/templates/otel-collector-configmap.yaml
@@ -62,6 +62,8 @@ data:
         namespace: {{ .Release.Namespace }}
         send_timestamps: true
         enable_open_metrics: true
+        resource_to_telemetry_conversion:
+          enabled: true
   {{- range $name, $cfg := (default dict .Values.global.observability.metrics.extraExporters) }}
       {{ $name }}: {{- toYaml $cfg | nindent 8 }}
   {{- end }}

--- a/charts/glassflow-etl/templates/otlp-receiver-deployment.yaml
+++ b/charts/glassflow-etl/templates/otlp-receiver-deployment.yaml
@@ -99,6 +99,16 @@ spec:
             - configMapRef:
                 name: {{ .Release.Name }}-otlp-receiver-config
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.instance.id=$(POD_NAME),service.namespace=$(POD_NAMESPACE)"
             {{- if .Values.postgresql.enabled }}
             - name: GLASSFLOW_DATABASE_URL
               valueFrom:


### PR DESCRIPTION
## Summary

- Closes [ETL-1140](https://linear.app/glassflow/issue/ETL-1140): OTLP-pushing pods (otlp-receiver, api) collapsed into a single Prometheus series, causing non-monotonic counter resets and broken `histogram_quantile` — confirmed on staging with 10 receiver replicas.
- Two fixes required together: the collector must convert resource attributes to labels, and each pod must carry a unique `service.instance.id`.

## Changes

- **otel-collector-configmap.yaml**: add `resource_to_telemetry_conversion: enabled: true` to the Prometheus exporter block — makes resource attributes (`service.instance.id`, `service.name`, etc.) appear as Prometheus labels instead of being dropped
- **otlp-receiver-deployment.yaml** + **deployment.yaml (api)**: inject `POD_NAME`/`POD_NAMESPACE` via downward API and set `OTEL_RESOURCE_ATTRIBUTES=service.instance.id=$(POD_NAME),service.namespace=$(POD_NAMESPACE)` — mirrors the pattern already used by operator-managed sink/ingestor pods which aggregate correctly today
- Chart bumped to **0.5.19**

## Test plan

- [ ] `helm lint charts/glassflow-etl` passes
- [ ] `helm template` shows `OTEL_RESOURCE_ATTRIBUTES` on both otlp-receiver and api containers, and `resource_to_telemetry_conversion: enabled: true` in the collector config
- [ ] After `helm upgrade` on a cluster with ≥2 receiver replicas: `curl /metrics | grep receiver_request_count_total` shows N distinct `service_instance_id` series, one per pod
- [ ] `sum(receiver_request_count_total)` is monotonic over 1 min with no traffic

## Rollback

Revert PR — no migrations or state changes.