### PR TITLE
Release 0.5.19 - Backpressure for OTLP and Kafka pipelines + fixes

### DIFF
--- a/charts/glassflow-etl/Chart.yaml
+++ b/charts/glassflow-etl/Chart.yaml
@@ -17,7 +17,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.18
+version: 0.5.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/glassflow-etl/templates/deployment.yaml
+++ b/charts/glassflow-etl/templates/deployment.yaml
@@ -45,6 +45,10 @@ spec:
         - name: ui
           image: "{{ .Values.global.imageRegistry | default "" }}{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
           imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.ui.service.targetPort | default 8080 }}
+              protocol: TCP
           {{- with .Values.ui.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -303,6 +307,10 @@ spec:
         - name: api
           image: "{{ .Values.global.imageRegistry | default "" }}{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.api.service.targetPort | default 8081 }}
+              protocol: TCP
           {{- with .Values.api.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/charts/glassflow-etl/templates/deployment.yaml
+++ b/charts/glassflow-etl/templates/deployment.yaml
@@ -311,6 +311,16 @@ spec:
             - configMapRef:
                 name: glassflow-api-config
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.instance.id=$(POD_NAME),service.namespace=$(POD_NAMESPACE)"
             {{- if .Values.postgresql.enabled }}
             - name: GLASSFLOW_DATABASE_URL
               valueFrom:

--- a/charts/glassflow-etl/templates/otel-collector-configmap.yaml
+++ b/charts/glassflow-etl/templates/otel-collector-configmap.yaml
@@ -62,6 +62,8 @@ data:
         namespace: {{ .Release.Namespace }}
         send_timestamps: true
         enable_open_metrics: true
+        resource_to_telemetry_conversion:
+          enabled: true
   {{- range $name, $cfg := (default dict .Values.global.observability.metrics.extraExporters) }}
       {{ $name }}: {{- toYaml $cfg | nindent 8 }}
   {{- end }}

--- a/charts/glassflow-etl/templates/otlp-receiver-deployment.yaml
+++ b/charts/glassflow-etl/templates/otlp-receiver-deployment.yaml
@@ -99,6 +99,16 @@ spec:
             - configMapRef:
                 name: {{ .Release.Name }}-otlp-receiver-config
           env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "service.instance.id=$(POD_NAME),service.namespace=$(POD_NAMESPACE)"
             {{- if .Values.postgresql.enabled }}
             - name: GLASSFLOW_DATABASE_URL
               valueFrom:

--- a/charts/glassflow-etl/templates/ui-configmap.yaml
+++ b/charts/glassflow-etl/templates/ui-configmap.yaml
@@ -33,6 +33,11 @@ data:
   AUTH0_ISSUER_BASE_URL: "{{ .Values.ui.auth0.issuerBaseUrl }}"
   AUTH0_CLIENT_ID: "{{ .Values.ui.auth0.clientId }}"
   AUTH0_CLIENT_SECRET: "{{ .Values.ui.auth0.clientSecret }}"
+  AUTH0_LOGIN_PATH: "{{ .Values.ui.auth0.loginPath | default "/api/auth/login" }}"
+  AUTH0_CALLBACK_PATH: "{{ .Values.ui.auth0.callbackPath | default "/api/auth/callback" }}"
+  AUTH0_LOGOUT_PATH: "{{ .Values.ui.auth0.logoutPath | default "/api/auth/logout" }}"
+  AUTH0_GITHUB_CONNECTION: "{{ .Values.ui.auth0.githubConnection | default "github" }}"
+  AUTH0_GOOGLE_CONNECTION: "{{ .Values.ui.auth0.googleConnection | default "google-oauth2" }}"
   {{- end }}
   {{- if .Values.ui.kafkaGateway.enabled }}
   KAFKA_GATEWAY_URL: "http://localhost:{{ .Values.ui.kafkaGateway.port }}"

--- a/charts/glassflow-etl/values.yaml
+++ b/charts/glassflow-etl/values.yaml
@@ -231,6 +231,13 @@ ui:
     clientId: ""
     # Auth0 client secret
     clientSecret: ""
+    # Auth0 route paths
+    loginPath: "/api/auth/login"
+    callbackPath: "/api/auth/callback"
+    logoutPath: "/api/auth/logout"
+    # Auth0 social connection names as configured in the Auth0 tenant
+    githubConnection: "github"
+    googleConnection: "google-oauth2"
 
   # Kafka Kerberos Gateway sidecar configuration
   # This sidecar provides Kerberos authentication support for Kafka connections

--- a/charts/glassflow-etl/values.yaml
+++ b/charts/glassflow-etl/values.yaml
@@ -11,7 +11,7 @@ global:
   imageRegistry: "ghcr.io/glassflow/"
   observability:
     metrics:
-      enabled: false
+      enabled: true
       # Additional exporters added alongside the built-in Prometheus exporter.
       # The Prometheus scrape endpoint (port 9090) is always enabled when metrics.enabled=true.
       # Use this map to push metrics to additional backends (e.g. otlp, otlphttp).
@@ -98,7 +98,7 @@ global:
       create: true
 
   usageStats:
-    enabled: false
+    enabled: true
     # Optional: provide an installation ID
     installationId: ""
 
@@ -152,8 +152,8 @@ api:
   logLevel: "info"
   image:
     repository: glassflow-etl-be
-    tag: main
-    pullPolicy: Always
+    tag: v3.1.0
+    pullPolicy: IfNotPresent
   resources:
     requests:
       memory: "100Mi"  # Memory request - adjust based on your workload
@@ -187,8 +187,8 @@ ui:
   replicas: 1
   image:
     repository: glassflow-etl-fe
-    tag: main
-    pullPolicy: Always
+    tag: v3.1.0
+    pullPolicy: IfNotPresent
   logLevel: "info"
   resources:
     requests:
@@ -239,7 +239,7 @@ ui:
     image:
       repository: kafka-kerberos-gateway
       tag: latest
-      pullPolicy: Always
+      pullPolicy: IfNotPresent
     resources:
       requests:
         memory: "128Mi"  # Memory request - gateway is lightweight
@@ -266,8 +266,8 @@ glassflow-operator:
       reconcileTimeout: 15m
       image:
         repository: glassflow-etl-k8s-operator
-        tag: main
-        pullPolicy: Always
+        tag: v3.1.0
+        pullPolicy: IfNotPresent
       resources:
         limits:
           cpu: 500m
@@ -282,8 +282,8 @@ glassflow-operator:
     ingestor:
       image:
         repository: glassflow-etl-ingestor
-        tag: main
-        pullPolicy: Always
+        tag: v3.1.0
+        pullPolicy: IfNotPresent
       logLevel: "INFO"
       resources:
         requests:
@@ -297,8 +297,8 @@ glassflow-operator:
     join:
       image:
         repository: glassflow-etl-join
-        tag: main
-        pullPolicy: Always
+        tag: v3.1.0
+        pullPolicy: IfNotPresent
       logLevel: "INFO"
       resources:
         requests:
@@ -312,8 +312,8 @@ glassflow-operator:
     sink:
       image:
         repository: glassflow-etl-sink
-        tag: main
-        pullPolicy: Always
+        tag: v3.1.0
+        pullPolicy: IfNotPresent
       logLevel: "INFO"
       resources:
         requests:
@@ -327,8 +327,8 @@ glassflow-operator:
     dedup:
       image:
         repository: glassflow-etl-dedup
-        tag: main
-        pullPolicy: Always
+        tag: v3.1.0
+        pullPolicy: IfNotPresent
       logLevel: "INFO"
       resources:
         requests:
@@ -349,12 +349,12 @@ sources:
   # OTLP Receiver - ingests OpenTelemetry data (logs, traces, metrics) via gRPC and HTTP
   # This is a shared service (one per installation) that routes data to pipelines via NATS
   otlpReceiver:
-    enabled: true
+    enabled: false
     replicas: 1
     image:
       repository: glassflow-etl-otlp-receiver
-      tag: main
-      pullPolicy: Always
+      tag: v3.1.0
+      pullPolicy: IfNotPresent
     resources:
       requests:
         memory: "256Mi"
@@ -369,7 +369,7 @@ sources:
     # Max concurrent in-flight batches before the receiver starts shedding load
     # (returns HTTP 503 / gRPC ResourceExhausted). Increase if you need higher
     # throughput but ensure the pod has enough CPU/memory headroom.
-    maxConcurrentRequests: 5
+    maxConcurrentRequests: 50
     # Max messages per NATS async-publish chunk. Keeps per-request memory bounded
     # regardless of upstream batch size.
     natsChunkSize: 1000
@@ -566,11 +566,11 @@ nats:
     merge:
       resources:
         requests:
-          memory: "2Gi"
-          cpu: "1000m"
+          memory: "3Gi"
+          cpu: "4000m"
         limits:
-          memory: "2Gi"
-          cpu: "1000m"
+          memory: "3Gi"
+          cpu: "4000m"
 
 # =============================================================================
 # INGRESS CONFIGURATION

--- a/charts/glassflow-etl/values.yaml
+++ b/charts/glassflow-etl/values.yaml
@@ -11,7 +11,7 @@ global:
   imageRegistry: "ghcr.io/glassflow/"
   observability:
     metrics:
-      enabled: true
+      enabled: false
       # Additional exporters added alongside the built-in Prometheus exporter.
       # The Prometheus scrape endpoint (port 9090) is always enabled when metrics.enabled=true.
       # Use this map to push metrics to additional backends (e.g. otlp, otlphttp).
@@ -98,7 +98,7 @@ global:
       create: true
 
   usageStats:
-    enabled: true
+    enabled: false
     # Optional: provide an installation ID
     installationId: ""
 
@@ -152,8 +152,8 @@ api:
   logLevel: "info"
   image:
     repository: glassflow-etl-be
-    tag: v3.1.0
-    pullPolicy: IfNotPresent
+    tag: main
+    pullPolicy: Always
   resources:
     requests:
       memory: "100Mi"  # Memory request - adjust based on your workload
@@ -187,8 +187,8 @@ ui:
   replicas: 1
   image:
     repository: glassflow-etl-fe
-    tag: v3.1.0
-    pullPolicy: IfNotPresent
+    tag: main
+    pullPolicy: Always
   logLevel: "info"
   resources:
     requests:
@@ -239,7 +239,7 @@ ui:
     image:
       repository: kafka-kerberos-gateway
       tag: latest
-      pullPolicy: IfNotPresent
+      pullPolicy: Always
     resources:
       requests:
         memory: "128Mi"  # Memory request - gateway is lightweight
@@ -266,8 +266,8 @@ glassflow-operator:
       reconcileTimeout: 15m
       image:
         repository: glassflow-etl-k8s-operator
-        tag: v3.1.0
-        pullPolicy: IfNotPresent
+        tag: main
+        pullPolicy: Always
       resources:
         limits:
           cpu: 500m
@@ -282,8 +282,8 @@ glassflow-operator:
     ingestor:
       image:
         repository: glassflow-etl-ingestor
-        tag: v3.1.0
-        pullPolicy: IfNotPresent
+        tag: main
+        pullPolicy: Always
       logLevel: "INFO"
       resources:
         requests:
@@ -297,8 +297,8 @@ glassflow-operator:
     join:
       image:
         repository: glassflow-etl-join
-        tag: v3.1.0
-        pullPolicy: IfNotPresent
+        tag: main
+        pullPolicy: Always
       logLevel: "INFO"
       resources:
         requests:
@@ -312,8 +312,8 @@ glassflow-operator:
     sink:
       image:
         repository: glassflow-etl-sink
-        tag: v3.1.0
-        pullPolicy: IfNotPresent
+        tag: main
+        pullPolicy: Always
       logLevel: "INFO"
       resources:
         requests:
@@ -327,8 +327,8 @@ glassflow-operator:
     dedup:
       image:
         repository: glassflow-etl-dedup
-        tag: v3.1.0
-        pullPolicy: IfNotPresent
+        tag: main
+        pullPolicy: Always
       logLevel: "INFO"
       resources:
         requests:
@@ -349,12 +349,12 @@ sources:
   # OTLP Receiver - ingests OpenTelemetry data (logs, traces, metrics) via gRPC and HTTP
   # This is a shared service (one per installation) that routes data to pipelines via NATS
   otlpReceiver:
-    enabled: false
+    enabled: true
     replicas: 1
     image:
       repository: glassflow-etl-otlp-receiver
-      tag: v3.1.0
-      pullPolicy: IfNotPresent
+      tag: main
+      pullPolicy: Always
     resources:
       requests:
         memory: "256Mi"
@@ -369,7 +369,7 @@ sources:
     # Max concurrent in-flight batches before the receiver starts shedding load
     # (returns HTTP 503 / gRPC ResourceExhausted). Increase if you need higher
     # throughput but ensure the pod has enough CPU/memory headroom.
-    maxConcurrentRequests: 50
+    maxConcurrentRequests: 5
     # Max messages per NATS async-publish chunk. Keeps per-request memory bounded
     # regardless of upstream batch size.
     natsChunkSize: 1000
@@ -566,11 +566,11 @@ nats:
     merge:
       resources:
         requests:
-          memory: "3Gi"
-          cpu: "4000m"
+          memory: "2Gi"
+          cpu: "1000m"
         limits:
-          memory: "3Gi"
-          cpu: "4000m"
+          memory: "2Gi"
+          cpu: "1000m"
 
 # =============================================================================
 # INGRESS CONFIGURATION


### PR DESCRIPTION
1. Backpressure for OTLP and kafka pipelines
2. New Observability metrics added and some fixed.
3. UI env changes from @vladamon 


TODO

- [ ] Update operator app and chart version
- [ ] Update ch-etl - api, ui, components and Otel reciever version